### PR TITLE
🚨 Hotfix: Fix update loop for versions 0.6.0-0.6.8

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptcode-cli",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "CLI tool for PromptCode - Generate AI-ready prompts from codebases",
   "bin": {
     "promptcode": "./dist/promptcode"


### PR DESCRIPTION
## Summary
- Fixed install script to skip broken update command in versions < 0.6.9
- Aligned CLI package.json version to 0.6.9

## Problem
Users on version 0.6.6 (and 0.6.0-0.6.8) were stuck in an update loop because:
1. These versions have a broken `update` command that downloads `.new` binary but lacks finalizer
2. The install script would detect the update command and try to use it
3. The update would fail to complete, leaving user on old version
4. Re-running install script would repeat the cycle

## Solution  
- Added version check to only use built-in update for versions >= 0.6.9
- Versions < 0.6.9 now get direct reinstall instead
- Clear messaging about the known issue

## Test plan
- [x] Tested version detection logic with multiple version strings
- [x] Linting passes
- [x] Build succeeds

## User workaround
Until merged, affected users can use:
```bash
curl -fsSL https://raw.githubusercontent.com/cogflows/promptcode-vscode/hotfix/update-loop-0.6.6/packages/cli/scripts/install.sh | bash
```

🤖 Generated with [Claude Code](https://claude.ai/code)