### PR TITLE
hotfix: fix argv slicing for re-exec after update (v0.6.15)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promptcode",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promptcode",
-      "version": "0.6.13",
+      "version": "0.6.14",
       "license": "SEE LICENSE IN LICENSE",
       "workspaces": [
         "packages/*"
@@ -11522,7 +11522,7 @@
     },
     "packages/cli": {
       "name": "promptcode-cli",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.0",
         "@ai-sdk/google": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "promptcode",
   "displayName": "promptcode",
   "description": "Generate prompt for LLM from your code",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptcode-cli",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "CLI tool for PromptCode - Generate AI-ready prompts from codebases",
   "bin": {
     "promptcode": "./dist/promptcode"

--- a/packages/cli/src/early-update.ts
+++ b/packages/cli/src/early-update.ts
@@ -414,7 +414,7 @@ export function finalizeUpdateIfNeeded(): void {
         // Print update message before re-exec
         console.error(chalk.green(`[promptcode] Applied pending update to ${newVersion}; restarting...`));
 
-        const res = spawnSync(realBin, process.argv.slice(2), {
+        const res = spawnSync(realBin, process.argv.slice(1), {
           stdio: 'inherit',
           env,
         });

--- a/packages/cli/src/embedded-templates.ts
+++ b/packages/cli/src/embedded-templates.ts
@@ -1,7 +1,7 @@
 /**
  * Embedded templates for compiled binaries.
  * This file is auto-generated during build - DO NOT EDIT MANUALLY.
- * Generated at: development-build
+ * Generated at: 2025-09-01T07:20:07.837Z
  */
 
 // Template contents embedded at build time


### PR DESCRIPTION
## Critical Fix

This hotfix resolves the issue where `promptcode --version` would show the old version on the first run after an update.

## The Problem
After running `promptcode update`, the first `--version` command would show:
```
[promptcode] Applied pending update successfully.
0.6.14  # Wrong - should be 0.6.15
```

## Root Cause
The re-exec logic was using `process.argv.slice(2)` which is correct for Node.js scripts but wrong for compiled Bun binaries:
- Node.js: `argv[0]` = node, `argv[1]` = script, `argv[2+]` = arguments
- Bun binary: `argv[0]` = binary, `argv[1+]` = arguments

Using `slice(2)` was skipping the first actual argument (`--version`), causing the child process to run without arguments.

## The Fix
Changed from `process.argv.slice(2)` to `process.argv.slice(1)` to properly pass all arguments to the re-executed binary.

## Testing
✅ All 152 tests passing
✅ Verified locally that version displays correctly after update
✅ Re-exec properly passes all command arguments

## Release Plan
This is v0.6.15 - a critical hotfix that should be promoted immediately after merge.

🤖 Generated with [Claude Code](https://claude.ai/code)