### PR TITLE
fix: update allowed-tools syntax for Bash permissions

### DIFF
--- a/.claude/commands/promptcode-ask-expert.md
+++ b/.claude/commands/promptcode-ask-expert.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Task, Read(/tmp/*), Read(/var/*), Write(/tmp/*), Write(/var/*), Edit(/tmp/*), Edit(/var/*), Edit(.promptcode/presets/*), Bash
+allowed-tools: Task, Read(/tmp/*), Read(/var/*), Write(/tmp/*), Write(/var/*), Edit(/tmp/*), Edit(/var/*), Edit(.promptcode/presets/*), Bash, Bash(*)
 description: Consult AI expert for complex problems with code context - supports ensemble mode for multiple models
 ---
 


### PR DESCRIPTION
## Summary
- Updated `allowed-tools` in `promptcode-ask-expert.md` to include both `Bash` and `Bash(*)`
- This should reduce unnecessary approval prompts for basic Bash commands

## Problem
The expert command was asking for approval for simple Bash commands like `TMP="${TMPDIR:-/tmp}"` even though `Bash` was in the allowed-tools list.

## Solution
Added `Bash(*)` alongside the existing `Bash` in the allowed-tools configuration for better compatibility with different Claude Code versions.

## Test Plan
- [ ] Test the `/promptcode-ask-expert` command in a clean Claude Code environment
- [ ] Verify that basic Bash commands don't trigger approval prompts
- [ ] Confirm that the expert consultation flow still works end-to-end

Fixes #38

🤖 Generated with [Claude Code](https://claude.ai/code)