### PR TITLE
feat: add GPT-5 Pro support and fix GPT-5 context windows

### DIFF
--- a/packages/cli/src/providers/models.ts
+++ b/packages/cli/src/providers/models.ts
@@ -8,7 +8,7 @@
  * Example: If a provider charges $0.001 per 1K tokens, 
  * the value here should be 1.0 (1000x conversion)
  * 
- * Pricing last updated: August 2025
+ * Pricing last updated: October 2025
  */
 
 import { z } from 'zod';
@@ -43,7 +43,7 @@ export const MODELS: Record<string, ModelConfig> = {
     modelId: 'gpt-5',
     name: 'GPT-5',
     description: 'State-of-the-art model with superior coding and reasoning',
-    contextWindow: 256000,
+    contextWindow: 400000,
     pricing: { input: 1.25, output: 10 },
     supportsWebSearch: true
   },
@@ -52,7 +52,7 @@ export const MODELS: Record<string, ModelConfig> = {
     modelId: 'gpt-5-mini',
     name: 'GPT-5 Mini',
     description: 'Balanced GPT-5 model for efficient performance',
-    contextWindow: 256000,
+    contextWindow: 400000,
     pricing: { input: 0.25, output: 2 },
     supportsWebSearch: true
   },
@@ -61,11 +61,20 @@ export const MODELS: Record<string, ModelConfig> = {
     modelId: 'gpt-5-nano',
     name: 'GPT-5 Nano',
     description: 'Ultra-fast GPT-5 model for quick tasks',
-    contextWindow: 256000,
+    contextWindow: 400000,
     pricing: { input: 0.05, output: 0.4 },
     supportsWebSearch: true
   },
-  
+  'gpt-5-pro': {
+    provider: 'openai',
+    modelId: 'gpt-5-pro',
+    name: 'GPT-5 Pro',
+    description: 'Most advanced reasoning model with extended thinking time',
+    contextWindow: 400000,
+    pricing: { input: 5, output: 20 },
+    supportsWebSearch: true
+  },
+
   // OpenAI O3 models (reasoning specialists)
   'o3': {
     provider: 'openai',


### PR DESCRIPTION
## Summary

Adds support for the new GPT-5 Pro model released by OpenAI in October 2025 and fixes incorrect context window sizes for all GPT-5 models.

## Changes

- **Add gpt-5-pro model**:
  - Model ID: `gpt-5-pro`  
  - Context: 400k tokens
  - Pricing: $5/M input, $20/M output
  - Description: "Most advanced reasoning model with extended thinking time"
  - Leverages existing generic GPT-5 handling (Responses API, reasoning_effort: high, textVerbosity: low, etc.)

- **Fix GPT-5 context windows**:
  - All GPT-5 models now correctly show 400k context (was incorrectly 256k)
  - Affects: gpt-5, gpt-5-mini, gpt-5-nano, gpt-5-pro
  - Per OpenAI docs: 272k input + 128k output = 400k total

- **Update pricing date**: August 2025 → October 2025

## Testing

- ✅ Model appears in `--models` list with correct metadata
- ✅ Cost estimation works correctly ($5/M input, $20/M output)
- ✅ Model executes successfully in mock mode
- ✅ All GPT-5 models show 400k context window
- ✅ 169/170 tests pass (1 unrelated flaky installer test timeout)

## Notes

- No code changes needed to ai-provider.ts - gpt-5-pro automatically handled by existing `modelKey.startsWith('gpt-5')` logic
- Minimal, focused change following the principle of generic solutions

Closes #49