### PR TITLE
fix: include workspace info in generated prompts for Apply & Review

### DIFF
--- a/.promptcode/presets/workspace-info-fix.patterns
+++ b/.promptcode/presets/workspace-info-fix.patterns
@@ -1,0 +1,16 @@
+# workspace-info-fix preset
+# Generated: 2025-12-01T15:01:17.153Z
+# Source: files optimized (6 → 5 patterns)
+# Optimization: balanced
+# Optimized: 4 files → 5 patterns (saved 0)
+# Applied rules:
+#   - almost-all-exclusion: packages/core/src/types (exclude 1)
+
+packages/core/src/types/**
+prompts/xml-outputs.md
+src/promptGenerator.ts
+src/webview/mergeTab.js
+!packages/core/src/types/index.ts
+!**/node_modules/**
+!**/dist/**
+!**/build/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **Apply & Review Workspace Resolution**: Generated prompts now include workspace info (name and root path) for each file, enabling LLMs to correctly output `<workspace_name>` and `<workspace_root>` tags. This fixes Apply & Review functionality in multi-root workspace scenarios. ([#58](https://github.com/cogflows/promptcode-vscode/issues/58))
+
 ## [0.9.0] - 2025-11-19
 
 ### Added

--- a/src/promptGenerator.ts
+++ b/src/promptGenerator.ts
@@ -294,16 +294,23 @@ export async function generatePrompt(
         log(`Adding content for ${selectedFiles.length} selected files...`);
         finalPromptText += '<file_contents>\n';
         for (const file of selectedFiles) {
+            // Defensive fallback for missing workspace info
+            const workspaceName = file.workspaceFolderName || 'workspace';
+            const workspacePath = file.workspaceFolderRootPath || workspaceRoot;
+
             try {
                 const fileContent = file.content ?? await readFileContent(file.absolutePath);
-                const relativePath = path.relative(file.workspaceFolderRootPath, file.absolutePath);
-                finalPromptText += `File: ${relativePath} (${file.tokenCount} tokens)\n`; 
+                const relativePath = path.relative(workspacePath, file.absolutePath);
+                finalPromptText += `File: ${relativePath} (${file.tokenCount} tokens)\n`;
+                finalPromptText += `Workspace: ${workspaceName} (${workspacePath})\n`;
                 finalPromptText += '```\n';
                 finalPromptText += fileContent;
                 finalPromptText += '\n```\n\n';
             } catch (error) {
                 log(`Error adding file content for ${file.absolutePath}:`, error);
-                finalPromptText += `File: ${file.path}\n<!-- Error reading file content: ${(error as Error).message} -->\n\n`;
+                finalPromptText += `File: ${file.path}\n`;
+                finalPromptText += `Workspace: ${workspaceName} (${workspacePath})\n`;
+                finalPromptText += `<!-- Error reading file content: ${(error as Error).message} -->\n\n`;
             }
         }
         finalPromptText += '</file_contents>\n\n'; 


### PR DESCRIPTION
## Summary
- Fixes the Apply & Review feature which expected LLMs to output `<workspace_name>` and `<workspace_root>` XML tags, but never provided this information in the generated prompt
- Adds workspace info (name and root path) after each file header in generated prompts
- Adds defensive fallbacks for missing workspace metadata
- Includes workspace info in error path for consistent format

## Test plan
- [x] All 110 automated tests pass
- [x] Reviewed by GPT-5.1 and Gemini 3 Pro (ensemble consultation)
- [x] Backwards compatible - additive change only

## New prompt format
```
File: src/index.ts (100 tokens)
Workspace: my-project (/Users/dev/my-project)
```

Fixes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)